### PR TITLE
Add word_to_coset fn, and only run todd-coxeter once

### DIFF
--- a/tc.h
+++ b/tc.h
@@ -43,11 +43,15 @@ class Congruence {
     return _active;
   }
 
+  coset_t word_to_coset (word_t);
+
  private:
   void new_coset(coset_t const&, letter_t const&);
   void identify_cosets(coset_t, coset_t);
   inline void trace(coset_t const&, relation_t const&, bool add = true);
   void check_forwd();
+
+  bool                         _tc_done;  // Has todd_coxeter already been run?
 
   coset_t                      _id_coset; // TODO: Remove?
   size_t                       _nrgens;


### PR DESCRIPTION
This adds a `word-to-coset` function, which takes a word, applies it to the identity coset, and returns the coset which is reached.  This is used, for example, in determining whether two words are equal in the semigroup.

We also add a check to make sure that the `todd-coxeter` function is only completed once, since all possible information is learned when the function is completed.